### PR TITLE
Fixing a bug that allowed users to get free funds

### DIFF
--- a/lib/travel_calculator/journey_menu.rb
+++ b/lib/travel_calculator/journey_menu.rb
@@ -52,16 +52,17 @@ class JourneyMenu
   def fetch_origin
     @origin = find_station
 
-    # Catches issue where if you entered an origin then purposefully failed the card lookup, you could gain
-    # funds on your card because you were never charged but gained the 'refund' from the post-travel calculation.
+    # Catches issue where if you entered an origin then purposefully failed the card lookup or had a negative card
+    # balance, you could gain funds on your card because you were never charged but gained the 'refund' from the
+    # post-travel calculation.
     begin
       card = find_card
+      @fare_calculator.default_charge(card)
     rescue InputError
       @origin = nil
       raise
     end
 
-    @fare_calculator.default_charge(card)
     display_welcome
   end
 

--- a/spec/lib/travel_calculator/journey_menu_spec.rb
+++ b/spec/lib/travel_calculator/journey_menu_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe JourneyMenu do
       expect(subject.instance_variable_get(:@origin)).to eq(nil)
     end
 
+    it 'clears the origin station if an error is raised when attempting to go on a journey' do
+      allow(subject.instance_variable_get(:@fare_calculator)).to receive(:default_charge).and_raise(InputError)
+
+      expect { subject.send(:fetch_origin) }.to raise_error(InputError)
+      expect(subject.instance_variable_get(:@origin)).to eq(nil)
+    end
+
     it 're-renders the menu' do
       expect(subject).to receive(:display_welcome)
 


### PR DESCRIPTION
If a user were to have a negative balance, attempt to make a journey, be informed of their negative balance, then enter a destination station, they would be 'refunded' the difference between the maximum charge and the fare between the two entered stations, despite never having been charged.

This resulted in a free top-up for the user, but it has now been patched.